### PR TITLE
認証api作成

### DIFF
--- a/src/laravel/.gitignore
+++ b/src/laravel/.gitignore
@@ -9,6 +9,7 @@
 /storage/*.key
 /vendor
 .env
+.env.testing
 .env.backup
 .phpunit.result.cache
 Homestead.json

--- a/src/laravel/app/Http/Controllers/Auth/LoginController.php
+++ b/src/laravel/app/Http/Controllers/Auth/LoginController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Auth;
 
+use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
@@ -36,5 +37,10 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
+    }
+
+    protected function authenticated(Request $request, $user)
+    {
+        return $user;
     }
 }

--- a/src/laravel/app/Http/Controllers/Auth/LoginController.php
+++ b/src/laravel/app/Http/Controllers/Auth/LoginController.php
@@ -39,8 +39,18 @@ class LoginController extends Controller
         $this->middleware('guest')->except('logout');
     }
 
+    // ログイン後に行われる処理のオーバーライド
     protected function authenticated(Request $request, $user)
     {
         return $user;
+    }
+
+    // ログアウト後に行われる処理のオーバーライド
+    protected function loggedOut(Request $request)
+    {
+        // セッションを再生成する
+        $request->session()->regenerate();
+
+        return response()->json();
     }
 }

--- a/src/laravel/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/laravel/app/Http/Controllers/Auth/RegisterController.php
@@ -8,6 +8,7 @@ use App\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Http\Request;
 
 class RegisterController extends Controller
 {
@@ -69,5 +70,12 @@ class RegisterController extends Controller
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
         ]);
+    }
+
+    // RegistersUsers.phpのオーバーライド
+    // Api利用のため、デフォルトのリダイレクト処理ではなくユーザーの返却に変更
+    protected function registered(Request $request, $user)
+    {
+        return $user;
     }
 }

--- a/src/laravel/app/Providers/RouteServiceProvider.php
+++ b/src/laravel/app/Providers/RouteServiceProvider.php
@@ -73,7 +73,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::prefix('api')
-             ->middleware('api')
+             ->middleware('web') //画面遷移用のルーティングをapiルートにて管理するため
              ->namespace($this->namespace)
              ->group(base_path('routes/api.php'));
     }

--- a/src/laravel/config/database.php
+++ b/src/laravel/config/database.php
@@ -63,6 +63,26 @@ return [
             ]) : [],
         ],
 
+        'mysql_testing' => [
+            'driver' => 'mysql',
+            'url' => env('DATABASE_URL'),
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '3306'),
+            'database' => env('DB_DATABASE', 'forge'),
+            'username' => env('DB_USERNAME', 'forge'),
+            'password' => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'strict' => true,
+            'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],
+
         'pgsql' => [
             'driver' => 'pgsql',
             'url' => env('DATABASE_URL'),

--- a/src/laravel/routes/api.php
+++ b/src/laravel/routes/api.php
@@ -5,6 +5,9 @@ use Illuminate\Http\Request;
 // 会員登録
 Route::post('/register', 'Auth\RegisterController@register')->name('register');
 
+// ログイン
+Route::post('/login', 'Auth\LoginController@login')->name('login');
+
 // Route::middleware('auth:api')->get('/user', function (Request $request) {
 //     return $request->user();
 // });

--- a/src/laravel/routes/api.php
+++ b/src/laravel/routes/api.php
@@ -2,17 +2,9 @@
 
 use Illuminate\Http\Request;
 
-/*
-|--------------------------------------------------------------------------
-| API Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register API routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| is assigned the "api" middleware group. Enjoy building your API!
-|
-*/
+// 会員登録
+Route::post('/register', 'Auth\RegisterController@register')->name('register');
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
+// Route::middleware('auth:api')->get('/user', function (Request $request) {
+//     return $request->user();
+// });

--- a/src/laravel/routes/api.php
+++ b/src/laravel/routes/api.php
@@ -8,6 +8,9 @@ Route::post('/register', 'Auth\RegisterController@register')->name('register');
 // ログイン
 Route::post('/login', 'Auth\LoginController@login')->name('login');
 
+// ログアウト
+Route::post('/logout', 'Auth\LoginController@logout')->name('logout');
+
 // Route::middleware('auth:api')->get('/user', function (Request $request) {
 //     return $request->user();
 // });

--- a/src/laravel/tests/Feature/LoginApiTest.php
+++ b/src/laravel/tests/Feature/LoginApiTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\User;
+
+class LoginApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // テストユーザー作成
+        $this->user = factory(User::class)->create();
+    }
+
+    /**
+     * @test
+     */
+    public function should_登録済みのユーザーを認証して返却する()
+    {
+        $response = $this->json('POST', route('login'), [
+            'email' => $this->user->email,
+            'password' => 'password',
+        ]);
+
+        $response
+            ->assertStatus(200)
+            ->assertJson(['name' => $this->user->name]);
+
+        $this->assertAuthenticatedAs($this->user);
+    }
+}
+

--- a/src/laravel/tests/Feature/LogoutApiTest.php
+++ b/src/laravel/tests/Feature/LogoutApiTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\User;
+
+class LogoutApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // テストユーザー作成
+        $this->user = factory(User::class)->create();
+    }
+
+    /**
+     * @test
+     */
+    public function should_認証済みのユーザーをログアウトさせる()
+    {
+        // テストユーザーをログイン状態にさせてからログアウト処理の実行
+        $response = $this->actingAs($this->user)
+                         ->json('POST', route('logout'));
+
+        $response->assertStatus(200);
+        $this->assertGuest();
+
+    }
+}

--- a/src/laravel/tests/Feature/RegisterApiTest.php
+++ b/src/laravel/tests/Feature/RegisterApiTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\User;
+
+class RegisterApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+
+    public function shouls_新しいユーザーを追加して返却する()
+    {
+        $data = [
+            'name' => 'hoge user',
+            'email' => 'dummy@email.jp',
+            'password' => 'password',
+            'passwaord_confirmation' => 'password'
+        ];
+
+        // ユーザー登録
+        $response = $this->json('POST', route('register'), $data);
+
+        // ユーザー検索
+        $user = User::first();
+        $this->assertEquals($data['name'], $user->name);
+
+        $response
+            ->assertStatus(201)
+            ->assertJson(['name' => $user->name]);
+
+    }
+}

--- a/src/laravel/tests/Feature/RegisterApiTest.php
+++ b/src/laravel/tests/Feature/RegisterApiTest.php
@@ -18,10 +18,10 @@ class RegisterApiTest extends TestCase
     public function shouls_新しいユーザーを追加して返却する()
     {
         $data = [
-            'name' => 'hoge user',
+            'name' => 'hogeuser',
             'email' => 'dummy@email.jp',
             'password' => 'password',
-            'passwaord_confirmation' => 'password'
+            'password_confirmation' => 'password'
         ];
 
         // ユーザー登録


### PR DESCRIPTION
# what
- ユーザー登録、ログイン、ログアウトを行うためのApi作成
  - 今回はlaravel標準機能のAuthを使って実装
    - apiを叩いてAuthコントローラを起動させて各処理を行う
  - テストコードを用意し、phpunit経由で動作確認ずみ