### PR TITLE
写真投稿フォーム作成

### DIFF
--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -21566,8 +21566,10 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var vuex__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! vuex */ "./node_modules/vuex/dist/vuex.esm.js");
 /* harmony import */ var _auth__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./auth */ "./resources/js/store/auth.js");
 /* harmony import */ var _error__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./error */ "./resources/js/store/error.js");
+/* harmony import */ var _message__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./message */ "./resources/js/store/message.js");
 
  // ストア読み込み
+
 
 
 
@@ -21575,10 +21577,47 @@ vue__WEBPACK_IMPORTED_MODULE_0___default.a.use(vuex__WEBPACK_IMPORTED_MODULE_1__
 var store = new vuex__WEBPACK_IMPORTED_MODULE_1__["default"].Store({
   modules: {
     auth: _auth__WEBPACK_IMPORTED_MODULE_2__["default"],
-    error: _error__WEBPACK_IMPORTED_MODULE_3__["default"]
+    error: _error__WEBPACK_IMPORTED_MODULE_3__["default"],
+    message: _message__WEBPACK_IMPORTED_MODULE_4__["default"]
   }
 });
 /* harmony default export */ __webpack_exports__["default"] = (store);
+
+/***/ }),
+
+/***/ "./resources/js/store/message.js":
+/*!***************************************!*\
+  !*** ./resources/js/store/message.js ***!
+  \***************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+var state = {
+  content: ''
+};
+var mutations = {
+  setContent: function setContent(state, _ref) {
+    var content = _ref.content,
+        timeout = _ref.timeout;
+    state.content = content;
+
+    if (typeof timeout === 'undefined') {
+      timeout = 3000;
+    } // メッセージがタイムアウトを過ぎると自動で消去される
+
+
+    setTimeout(function () {
+      return state.content = '';
+    }, timeout);
+  }
+};
+/* harmony default export */ __webpack_exports__["default"] = ({
+  namespaced: true,
+  state: state,
+  mutations: mutations
+});
 
 /***/ }),
 

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -2123,6 +2123,15 @@ __webpack_require__.r(__webpack_exports__);
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
+
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+//
 //
 //
 //
@@ -2152,7 +2161,8 @@ __webpack_require__.r(__webpack_exports__);
   data: function data() {
     return {
       // previewにはプレビュー画像のデータURLが入る。初期値はnull
-      preview: null
+      preview: null,
+      photo: null
     };
   },
   methods: {
@@ -2161,7 +2171,9 @@ __webpack_require__.r(__webpack_exports__);
       // プレビューを消す
       this.preview = ''; // inputデータを消す this.$el.querySelectorはコンポーネントそのもののDOMを探すためのもの
 
-      this.$el.querySelector('input[type="file"]').value = null;
+      this.$el.querySelector('input[type="file"]').value = null; // 保持していた画像データの情報を消す
+
+      this.photo = null;
     },
     // フォームでファイルが選択されたら発火
     onFileChange: function onFileChange(event) {
@@ -2192,7 +2204,46 @@ __webpack_require__.r(__webpack_exports__);
       // 読み込まれたファイルはデータURL形式で受け取れる（上記onload参照）
 
 
-      reader.readAsDataURL(event.target.files[0]);
+      reader.readAsDataURL(event.target.files[0]); // 選択された画像をthis.photoとして保持
+
+      this.photo = event.target.files[0];
+    },
+    // 送信
+    submit: function submit() {
+      var _this2 = this;
+
+      return _asyncToGenerator(
+      /*#__PURE__*/
+      _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee() {
+        var formData, response;
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                // HTML5のFormDataAPIを使ってAjaxでファイル送信を行う
+                formData = new FormData(); // onFileChangeで保持したデータを代入
+
+                formData.append('photo', _this2.photo); // APIを叩く
+
+                _context.next = 4;
+                return axios.post('/api/photos', formData);
+
+              case 4:
+                response = _context.sent;
+
+                _this2.reset(); // NavbarのshowFormの値とPhotoFormのinputはv-modelでバインドされている
+                // ここでfalseを返すことで投稿完了時にフォームが閉じる
+
+
+                _this2.$emit('input', false);
+
+              case 7:
+              case "end":
+                return _context.stop();
+            }
+          }
+        }, _callee);
+      }))();
     }
   }
 });
@@ -3781,21 +3832,34 @@ var render = function() {
     [
       _c("h2", { staticClass: "title" }, [_vm._v("Submit a photo")]),
       _vm._v(" "),
-      _c("form", { staticClass: "form" }, [
-        _c("input", {
-          staticClass: "form__item",
-          attrs: { type: "file" },
-          on: { change: _vm.onFileChange }
-        }),
-        _vm._v(" "),
-        _vm.preview
-          ? _c("output", { staticClass: "form__output" }, [
-              _c("img", { attrs: { src: _vm.preview, alt: "" } })
-            ])
-          : _vm._e(),
-        _vm._v(" "),
-        _vm._m(0)
-      ])
+      _c(
+        "form",
+        {
+          staticClass: "form",
+          on: {
+            submit: function($event) {
+              $event.preventDefault()
+              return _vm.submit($event)
+            }
+          }
+        },
+        [
+          _vm._v(">\n    "),
+          _c("input", {
+            staticClass: "form__item",
+            attrs: { type: "file" },
+            on: { change: _vm.onFileChange }
+          }),
+          _vm._v(" "),
+          _vm.preview
+            ? _c("output", { staticClass: "form__output" }, [
+                _c("img", { attrs: { src: _vm.preview, alt: "" } })
+              ])
+            : _vm._e(),
+          _vm._v(" "),
+          _vm._m(0)
+        ]
+      )
     ]
   )
 }
@@ -20662,14 +20726,15 @@ __webpack_require__.r(__webpack_exports__);
 /*!***********************************************!*\
   !*** ./resources/js/components/PhotoForm.vue ***!
   \***********************************************/
-/*! exports provided: default */
+/*! no static exports found */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _PhotoForm_vue_vue_type_template_id_516c053b___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./PhotoForm.vue?vue&type=template&id=516c053b& */ "./resources/js/components/PhotoForm.vue?vue&type=template&id=516c053b&");
 /* harmony import */ var _PhotoForm_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./PhotoForm.vue?vue&type=script&lang=js& */ "./resources/js/components/PhotoForm.vue?vue&type=script&lang=js&");
-/* empty/unused harmony star reexport *//* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+/* harmony reexport (unknown) */ for(var __WEBPACK_IMPORT_KEY__ in _PhotoForm_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__) if(__WEBPACK_IMPORT_KEY__ !== 'default') (function(key) { __webpack_require__.d(__webpack_exports__, key, function() { return _PhotoForm_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__[key]; }) }(__WEBPACK_IMPORT_KEY__));
+/* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
 
 
 
@@ -20699,7 +20764,7 @@ component.options.__file = "resources/js/components/PhotoForm.vue"
 /*!************************************************************************!*\
   !*** ./resources/js/components/PhotoForm.vue?vue&type=script&lang=js& ***!
   \************************************************************************/
-/*! exports provided: default */
+/*! no static exports found */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -3847,7 +3847,6 @@ var render = function() {
           }
         },
         [
-          _vm._v(">\n    "),
           _c("input", {
             staticClass: "form__item",
             attrs: { type: "file" },
@@ -4233,6 +4232,30 @@ var staticRenderFns = [
     ])
   }
 ]
+render._withStripped = true
+
+
+
+/***/ }),
+
+/***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/pages/PhotoDetail.vue?vue&type=template&id=c17cd6ac&":
+/*!*********************************************************************************************************************************************************************************************************!*\
+  !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/pages/PhotoDetail.vue?vue&type=template&id=c17cd6ac& ***!
+  \*********************************************************************************************************************************************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c("h1", [_vm._v("Photo Detail")])
+}
+var staticRenderFns = []
 render._withStripped = true
 
 
@@ -20864,6 +20887,59 @@ __webpack_require__.r(__webpack_exports__);
 
 /***/ }),
 
+/***/ "./resources/js/pages/PhotoDetail.vue":
+/*!********************************************!*\
+  !*** ./resources/js/pages/PhotoDetail.vue ***!
+  \********************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _PhotoDetail_vue_vue_type_template_id_c17cd6ac___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./PhotoDetail.vue?vue&type=template&id=c17cd6ac& */ "./resources/js/pages/PhotoDetail.vue?vue&type=template&id=c17cd6ac&");
+/* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+
+var script = {}
+
+
+/* normalize component */
+
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__["default"])(
+  script,
+  _PhotoDetail_vue_vue_type_template_id_c17cd6ac___WEBPACK_IMPORTED_MODULE_0__["render"],
+  _PhotoDetail_vue_vue_type_template_id_c17cd6ac___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
+  false,
+  null,
+  null,
+  null
+  
+)
+
+/* hot reload */
+if (false) { var api; }
+component.options.__file = "resources/js/pages/PhotoDetail.vue"
+/* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+
+/***/ "./resources/js/pages/PhotoDetail.vue?vue&type=template&id=c17cd6ac&":
+/*!***************************************************************************!*\
+  !*** ./resources/js/pages/PhotoDetail.vue?vue&type=template&id=c17cd6ac& ***!
+  \***************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_PhotoDetail_vue_vue_type_template_id_c17cd6ac___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!../../../node_modules/vue-loader/lib??vue-loader-options!./PhotoDetail.vue?vue&type=template&id=c17cd6ac& */ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/pages/PhotoDetail.vue?vue&type=template&id=c17cd6ac&");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_PhotoDetail_vue_vue_type_template_id_c17cd6ac___WEBPACK_IMPORTED_MODULE_0__["render"]; });
+
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_PhotoDetail_vue_vue_type_template_id_c17cd6ac___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+
+
+
+/***/ }),
+
 /***/ "./resources/js/pages/PhotoList.vue":
 /*!******************************************!*\
   !*** ./resources/js/pages/PhotoList.vue ***!
@@ -20985,9 +21061,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _pages_PhotoList_vue__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./pages/PhotoList.vue */ "./resources/js/pages/PhotoList.vue");
 /* harmony import */ var _pages_Login_vue__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./pages/Login.vue */ "./resources/js/pages/Login.vue");
 /* harmony import */ var _pages_errors_System_vue__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./pages/errors/System.vue */ "./resources/js/pages/errors/System.vue");
-/* harmony import */ var _store__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ./store */ "./resources/js/store/index.js");
+/* harmony import */ var _pages_PhotoDetail_vue__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ./pages/PhotoDetail.vue */ "./resources/js/pages/PhotoDetail.vue");
+/* harmony import */ var _store__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./store */ "./resources/js/store/index.js");
 
  // ページコンポーネントをインポートする
+
 
 
 
@@ -21002,13 +21080,13 @@ var routes = [{
   component: _pages_PhotoList_vue__WEBPACK_IMPORTED_MODULE_2__["default"]
 }, {
   path: '/photos/:id',
-  component: PhotoDetail,
+  component: _pages_PhotoDetail_vue__WEBPACK_IMPORTED_MODULE_5__["default"],
   props: true
 }, {
   path: '/login',
   component: _pages_Login_vue__WEBPACK_IMPORTED_MODULE_3__["default"],
   beforeEnter: function beforeEnter(to, from, next) {
-    if (_store__WEBPACK_IMPORTED_MODULE_5__["default"].getters['auth/check']) {
+    if (_store__WEBPACK_IMPORTED_MODULE_6__["default"].getters['auth/check']) {
       next('/');
     } else {
       next();

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -2135,6 +2135,9 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 //
+//
+//
+//
 /* harmony default export */ __webpack_exports__["default"] = ({
   // 親要素(navbar)側で制御を行うためpropsを用いる
   // propsに送られたvalueを参照して小要素(PhotoForm)の内容が決まる
@@ -2144,6 +2147,52 @@ __webpack_require__.r(__webpack_exports__);
       type: Boolean,
       // requiredがないとエラーなどで真偽値情報が飛んだ時に動作しなくなる
       required: true
+    }
+  },
+  data: function data() {
+    return {
+      // previewにはプレビュー画像のデータURLが入る。初期値はnull
+      preview: null
+    };
+  },
+  methods: {
+    // プレビューリセット
+    reset: function reset() {
+      // プレビューを消す
+      this.preview = ''; // inputデータを消す this.$el.querySelectorはコンポーネントそのもののDOMを探すためのもの
+
+      this.$el.querySelector('input[type="file"]').value = null;
+    },
+    // フォームでファイルが選択されたら発火
+    onFileChange: function onFileChange(event) {
+      var _this = this;
+
+      // エラーハンドリング1 何も選択されていなかったら処理中断
+      if (event.target.files.length === 0) {
+        this.reset();
+        return false;
+      } // エラーハンドリング2 画像ファイル以外が選択されていたら処理中断
+
+
+      if (!event.target.files[0].type.match('image.*')) {
+        this.reset();
+        return false;
+      } // FileReaderクラスのインスタンスを取得
+
+
+      var reader = new FileReader(); // ファイルを読み込み終わったタイミングで実行する処理
+
+      reader.onload = function (e) {
+        // previewに読み込み結果（データURL）を代入する
+        // previewに値が入ると<output>につけたv-ifがtrueと判定される
+        // また<output>内部の<img>のsrc属性はpreviewの値を参照しているので
+        // 結果として画像が表示される
+        _this.preview = e.target.result;
+      }; // ファイルを読み込む
+      // 読み込まれたファイルはデータURL形式で受け取れる（上記onload参照）
+
+
+      reader.readAsDataURL(event.target.files[0]);
     }
   }
 });
@@ -3732,7 +3781,21 @@ var render = function() {
     [
       _c("h2", { staticClass: "title" }, [_vm._v("Submit a photo")]),
       _vm._v(" "),
-      _vm._m(0)
+      _c("form", { staticClass: "form" }, [
+        _c("input", {
+          staticClass: "form__item",
+          attrs: { type: "file" },
+          on: { change: _vm.onFileChange }
+        }),
+        _vm._v(" "),
+        _vm.preview
+          ? _c("output", { staticClass: "form__output" }, [
+              _c("img", { attrs: { src: _vm.preview, alt: "" } })
+            ])
+          : _vm._e(),
+        _vm._v(" "),
+        _vm._m(0)
+      ])
     ]
   )
 }
@@ -3741,16 +3804,12 @@ var staticRenderFns = [
     var _vm = this
     var _h = _vm.$createElement
     var _c = _vm._self._c || _h
-    return _c("form", { staticClass: "form" }, [
-      _c("input", { staticClass: "form__item", attrs: { type: "file" } }),
-      _vm._v(" "),
-      _c("div", { staticClass: "form__button" }, [
-        _c(
-          "button",
-          { staticClass: "button button--inverse", attrs: { type: "submit" } },
-          [_vm._v("submit")]
-        )
-      ])
+    return _c("div", { staticClass: "form__button" }, [
+      _c(
+        "button",
+        { staticClass: "button button--inverse", attrs: { type: "submit" } },
+        [_vm._v("submit")]
+      )
     ])
   }
 ]

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -2126,6 +2126,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
 /* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../util */ "./resources/js/util.js");
+/* harmony import */ var _Loader_vue__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./Loader.vue */ "./resources/js/components/Loader.vue");
 
 
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
@@ -2153,8 +2154,15 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 //
 //
 //
+//
+//
+//
+
 
 /* harmony default export */ __webpack_exports__["default"] = ({
+  components: {
+    Loader: _Loader_vue__WEBPACK_IMPORTED_MODULE_2__["default"]
+  },
   // 親要素(navbar)側で制御を行うためpropsを用いる
   // propsに送られたvalueを参照して小要素(PhotoForm)の内容が決まる
   props: {
@@ -2167,6 +2175,8 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
   },
   data: function data() {
     return {
+      // ロード画面の初期設定は非表示
+      loading: false,
       // previewにはプレビュー画像のデータURLが入る。初期値はnull
       preview: null,
       photo: null,
@@ -2228,26 +2238,30 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
-                // HTML5のFormDataAPIを使ってAjaxでファイル送信を行う
+                // ロード画面を表示
+                _this2.loading = true; // HTML5のFormDataAPIを使ってAjaxでファイル送信を行う
+
                 formData = new FormData(); // onFileChangeで保持したデータを代入
 
                 formData.append('photo', _this2.photo); // APIを叩く
 
-                _context.next = 4;
+                _context.next = 5;
                 return axios.post('/api/photos', formData);
 
-              case 4:
+              case 5:
                 response = _context.sent;
+                _this2.loading = false; // バリデーションエラーの場合はreturn falseで処理自体を中断
+                // 入力されたフォーム内容は保持したままエラーメッセージの取得に進む
 
                 if (!(response.status === _util__WEBPACK_IMPORTED_MODULE_1__["UNPROCESSABLE_ENTITY"])) {
-                  _context.next = 8;
+                  _context.next = 10;
                   break;
                 }
 
                 _this2.errors = response.data.errors;
                 return _context.abrupt("return", false);
 
-              case 8:
+              case 10:
                 // 投稿処理終了時にリセット
                 _this2.reset(); // NavbarのshowFormの値とPhotoFormのinputはv-modelでバインドされている
                 // ここでfalseを返すことで投稿完了時にフォームが閉じる
@@ -2257,7 +2271,7 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 
 
                 if (!(response.status !== _util__WEBPACK_IMPORTED_MODULE_1__["CREATED"])) {
-                  _context.next = 13;
+                  _context.next = 15;
                   break;
                 }
 
@@ -2265,11 +2279,11 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 
                 return _context.abrupt("return", false);
 
-              case 13:
+              case 15:
                 // 投稿後は詳細ページに画面遷移
                 _this2.$router.push("/photos/".concat(response.data.id));
 
-              case 14:
+              case 16:
               case "end":
                 return _context.stop();
             }
@@ -3748,6 +3762,48 @@ render._withStripped = true
 
 /***/ }),
 
+/***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Loader.vue?vue&type=template&id=e79ec684&":
+/*!*********************************************************************************************************************************************************************************************************!*\
+  !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/Loader.vue?vue&type=template&id=e79ec684& ***!
+  \*********************************************************************************************************************************************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c("div", { staticClass: "loader" }, [
+    _c(
+      "p",
+      { staticClass: "loading__text" },
+      [_vm._t("default", [_vm._v("Loading...")])],
+      2
+    ),
+    _vm._v(" "),
+    _vm._m(0)
+  ])
+}
+var staticRenderFns = [
+  function() {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("div", { staticClass: "loader__item loader__item--heart" }, [
+      _c("div")
+    ])
+  }
+]
+render._withStripped = true
+
+
+
+/***/ }),
+
 /***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Navbar.vue?vue&type=template&id=6dde423b&":
 /*!*********************************************************************************************************************************************************************************************************!*\
   !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/Navbar.vue?vue&type=template&id=6dde423b& ***!
@@ -3865,8 +3921,33 @@ var render = function() {
       _c("h2", { staticClass: "title" }, [_vm._v("Submit a photo")]),
       _vm._v(" "),
       _c(
+        "div",
+        {
+          directives: [
+            {
+              name: "show",
+              rawName: "v-show",
+              value: _vm.loading,
+              expression: "loading"
+            }
+          ],
+          staticClass: "panel"
+        },
+        [_c("Loader", [_vm._v("Sending your photo...")])],
+        1
+      ),
+      _vm._v(" "),
+      _c(
         "form",
         {
+          directives: [
+            {
+              name: "show",
+              rawName: "v-show",
+              value: !_vm.loading,
+              expression: "! loading"
+            }
+          ],
           staticClass: "form",
           on: {
             submit: function($event) {
@@ -20717,6 +20798,59 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Footer_vue_vue_type_template_id_61a7c374___WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Footer_vue_vue_type_template_id_61a7c374___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+
+
+
+/***/ }),
+
+/***/ "./resources/js/components/Loader.vue":
+/*!********************************************!*\
+  !*** ./resources/js/components/Loader.vue ***!
+  \********************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _Loader_vue_vue_type_template_id_e79ec684___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Loader.vue?vue&type=template&id=e79ec684& */ "./resources/js/components/Loader.vue?vue&type=template&id=e79ec684&");
+/* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+
+var script = {}
+
+
+/* normalize component */
+
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__["default"])(
+  script,
+  _Loader_vue_vue_type_template_id_e79ec684___WEBPACK_IMPORTED_MODULE_0__["render"],
+  _Loader_vue_vue_type_template_id_e79ec684___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
+  false,
+  null,
+  null,
+  null
+  
+)
+
+/* hot reload */
+if (false) { var api; }
+component.options.__file = "resources/js/components/Loader.vue"
+/* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+
+/***/ "./resources/js/components/Loader.vue?vue&type=template&id=e79ec684&":
+/*!***************************************************************************!*\
+  !*** ./resources/js/components/Loader.vue?vue&type=template&id=e79ec684& ***!
+  \***************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Loader_vue_vue_type_template_id_e79ec684___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!../../../node_modules/vue-loader/lib??vue-loader-options!./Loader.vue?vue&type=template&id=e79ec684& */ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Loader.vue?vue&type=template&id=e79ec684&");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Loader_vue_vue_type_template_id_e79ec684___WEBPACK_IMPORTED_MODULE_0__["render"]; });
+
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Loader_vue_vue_type_template_id_e79ec684___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -2235,9 +2235,12 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
                 // ここでfalseを返すことで投稿完了時にフォームが閉じる
 
 
-                _this2.$emit('input', false);
+                _this2.$emit('input', false); // 投稿後は詳細ページに画面遷移
 
-              case 7:
+
+                _this2.$router.push("/photos/".concat(response.data.id));
+
+              case 8:
               case "end":
                 return _context.stop();
             }
@@ -20997,6 +21000,10 @@ vue__WEBPACK_IMPORTED_MODULE_0___default.a.use(vue_router__WEBPACK_IMPORTED_MODU
 var routes = [{
   path: '/',
   component: _pages_PhotoList_vue__WEBPACK_IMPORTED_MODULE_2__["default"]
+}, {
+  path: '/photos/:id',
+  component: PhotoDetail,
+  props: true
 }, {
   path: '/login',
   component: _pages_Login_vue__WEBPACK_IMPORTED_MODULE_3__["default"],

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -1920,9 +1920,10 @@ module.exports = {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _components_Navbar__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./components/Navbar */ "./resources/js/components/Navbar.vue");
-/* harmony import */ var _components_Footer__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./components/Footer */ "./resources/js/components/Footer.vue");
-/* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./util */ "./resources/js/util.js");
+/* harmony import */ var _components_Message_vue__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./components/Message.vue */ "./resources/js/components/Message.vue");
+/* harmony import */ var _components_Navbar__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./components/Navbar */ "./resources/js/components/Navbar.vue");
+/* harmony import */ var _components_Footer__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./components/Footer */ "./resources/js/components/Footer.vue");
+/* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./util */ "./resources/js/util.js");
 //
 //
 //
@@ -1942,13 +1943,16 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 //
+//
+
 
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   components: {
-    Navbar: _components_Navbar__WEBPACK_IMPORTED_MODULE_0__["default"],
-    Footer: _components_Footer__WEBPACK_IMPORTED_MODULE_1__["default"]
+    Message: _components_Message_vue__WEBPACK_IMPORTED_MODULE_0__["default"],
+    Navbar: _components_Navbar__WEBPACK_IMPORTED_MODULE_1__["default"],
+    Footer: _components_Footer__WEBPACK_IMPORTED_MODULE_2__["default"]
   },
   // 算出プロパティ
   computed: {
@@ -1962,7 +1966,7 @@ __webpack_require__.r(__webpack_exports__);
     errorCode: {
       handler: function handler(val) {
         // errorCodeの引数にINTERNAL_SERVER_ERRORが入った場合の処理
-        if (val === _util__WEBPACK_IMPORTED_MODULE_2__["INTERNAL_SERVER_ERROR"]) {
+        if (val === _util__WEBPACK_IMPORTED_MODULE_3__["INTERNAL_SERVER_ERROR"]) {
           this.$router.push('/500');
         }
       },
@@ -2048,6 +2052,39 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
       }))();
     }
   }
+});
+
+/***/ }),
+
+/***/ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Message.vue?vue&type=script&lang=js&":
+/*!******************************************************************************************************************************************************************!*\
+  !*** ./node_modules/babel-loader/lib??ref--4-0!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/Message.vue?vue&type=script&lang=js& ***!
+  \******************************************************************************************************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var vuex__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! vuex */ "./node_modules/vuex/dist/vuex.esm.js");
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+//
+//
+//
+//
+//
+//
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  computed: _objectSpread({}, Object(vuex__WEBPACK_IMPORTED_MODULE_0__["mapState"])({
+    message: function message(state) {
+      return state.message.content;
+    }
+  }))
 });
 
 /***/ }),
@@ -2280,10 +2317,16 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
                 return _context.abrupt("return", false);
 
               case 15:
-                // 投稿後は詳細ページに画面遷移
+                // 投稿処理が問題なく完了した場合はメッセージ登録
+                _this2.$store.commit('message/setContent', {
+                  content: '写真が投稿されました！',
+                  timeout: 6000
+                }); // 投稿後は詳細ページに画面遷移
+
+
                 _this2.$router.push("/photos/".concat(response.data.id));
 
-              case 16:
+              case 17:
               case "end":
                 return _context.stop();
             }
@@ -3708,7 +3751,12 @@ var render = function() {
     _c("header", [_c("Navbar")], 1),
     _vm._v(" "),
     _c("main", [
-      _c("div", { staticClass: "container" }, [_c("RouterView")], 1)
+      _c(
+        "div",
+        { staticClass: "container" },
+        [_c("Message"), _vm._v(" "), _c("RouterView")],
+        1
+      )
     ]),
     _vm._v(" "),
     _c("footer", [_c("Footer")], 1)
@@ -3798,6 +3846,44 @@ var staticRenderFns = [
     ])
   }
 ]
+render._withStripped = true
+
+
+
+/***/ }),
+
+/***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Message.vue?vue&type=template&id=b91a6428&":
+/*!**********************************************************************************************************************************************************************************************************!*\
+  !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/Message.vue?vue&type=template&id=b91a6428& ***!
+  \**********************************************************************************************************************************************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c(
+    "div",
+    {
+      directives: [
+        {
+          name: "show",
+          rawName: "v-show",
+          value: _vm.message,
+          expression: "message"
+        }
+      ],
+      staticClass: "message"
+    },
+    [_vm._v("\n  " + _vm._s(_vm.message) + "\n")]
+  )
+}
+var staticRenderFns = []
 render._withStripped = true
 
 
@@ -20851,6 +20937,75 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Loader_vue_vue_type_template_id_e79ec684___WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Loader_vue_vue_type_template_id_e79ec684___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+
+
+
+/***/ }),
+
+/***/ "./resources/js/components/Message.vue":
+/*!*********************************************!*\
+  !*** ./resources/js/components/Message.vue ***!
+  \*********************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _Message_vue_vue_type_template_id_b91a6428___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./Message.vue?vue&type=template&id=b91a6428& */ "./resources/js/components/Message.vue?vue&type=template&id=b91a6428&");
+/* harmony import */ var _Message_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./Message.vue?vue&type=script&lang=js& */ "./resources/js/components/Message.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport *//* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+
+
+
+
+
+/* normalize component */
+
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__["default"])(
+  _Message_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__["default"],
+  _Message_vue_vue_type_template_id_b91a6428___WEBPACK_IMPORTED_MODULE_0__["render"],
+  _Message_vue_vue_type_template_id_b91a6428___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
+  false,
+  null,
+  null,
+  null
+  
+)
+
+/* hot reload */
+if (false) { var api; }
+component.options.__file = "resources/js/components/Message.vue"
+/* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+
+/***/ "./resources/js/components/Message.vue?vue&type=script&lang=js&":
+/*!**********************************************************************!*\
+  !*** ./resources/js/components/Message.vue?vue&type=script&lang=js& ***!
+  \**********************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_Message_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/babel-loader/lib??ref--4-0!../../../node_modules/vue-loader/lib??vue-loader-options!./Message.vue?vue&type=script&lang=js& */ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Message.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_Message_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
+
+/***/ }),
+
+/***/ "./resources/js/components/Message.vue?vue&type=template&id=b91a6428&":
+/*!****************************************************************************!*\
+  !*** ./resources/js/components/Message.vue?vue&type=template&id=b91a6428& ***!
+  \****************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Message_vue_vue_type_template_id_b91a6428___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!../../../node_modules/vue-loader/lib??vue-loader-options!./Message.vue?vue&type=template&id=b91a6428& */ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/Message.vue?vue&type=template&id=b91a6428&");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Message_vue_vue_type_template_id_b91a6428___WEBPACK_IMPORTED_MODULE_0__["render"]; });
+
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Message_vue_vue_type_template_id_b91a6428___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -2061,6 +2061,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _PhotoForm_vue__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./PhotoForm.vue */ "./resources/js/components/PhotoForm.vue");
 //
 //
 //
@@ -2077,6 +2078,51 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 //
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  components: {
+    PhotoForm: _PhotoForm_vue__WEBPACK_IMPORTED_MODULE_0__["default"]
+  },
+  data: function data() {
+    return {
+      // デフォルトではfalseを設定。ボタンを押した際にフォームが表示される
+      showForm: false
+    };
+  },
+  computed: {
+    isLogin: function isLogin() {
+      return this.$store.getters['auth/check'];
+    },
+    username: function username() {
+      return this.$store.getters['auth/username'];
+    }
+  }
+});
+
+/***/ }),
+
+/***/ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/PhotoForm.vue?vue&type=script&lang=js&":
+/*!********************************************************************************************************************************************************************!*\
+  !*** ./node_modules/babel-loader/lib??ref--4-0!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/PhotoForm.vue?vue&type=script&lang=js& ***!
+  \********************************************************************************************************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
 //
 //
 //
@@ -2090,12 +2136,14 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 /* harmony default export */ __webpack_exports__["default"] = ({
-  computed: {
-    isLogin: function isLogin() {
-      return this.$store.getters['auth/check'];
-    },
-    username: function username() {
-      return this.$store.getters['auth/username'];
+  // 親要素(navbar)側で制御を行うためpropsを用いる
+  // propsに送られたvalueを参照して小要素(PhotoForm)の内容が決まる
+  props: {
+    // valueに真偽値を与えることでv-showが機能し、表示/非表示を切り替える
+    value: {
+      type: Boolean,
+      // requiredがないとエラーなどで真偽値情報が飛んだ時に動作しなくなる
+      required: true
     }
   }
 });
@@ -3593,7 +3641,23 @@ var render = function() {
       _vm._v(" "),
       _c("div", { staticClass: "navbar__menu" }, [
         _vm.isLogin
-          ? _c("div", { staticClass: "navbar__item" }, [_vm._m(0)])
+          ? _c("div", { staticClass: "navbar__item" }, [
+              _c(
+                "button",
+                {
+                  staticClass: "button",
+                  on: {
+                    click: function($event) {
+                      _vm.showForm = !_vm.showForm
+                    }
+                  }
+                },
+                [
+                  _c("i", { staticClass: "icon ion-md-add" }),
+                  _vm._v("\n        Submit a photo\n      ")
+                ]
+              )
+            ])
           : _vm._e(),
         _vm._v(" "),
         _vm.isLogin
@@ -3615,9 +3679,61 @@ var render = function() {
               ],
               1
             )
-      ])
+      ]),
+      _vm._v(" "),
+      _c("PhotoForm", {
+        model: {
+          value: _vm.showForm,
+          callback: function($$v) {
+            _vm.showForm = $$v
+          },
+          expression: "showForm"
+        }
+      })
     ],
     1
+  )
+}
+var staticRenderFns = []
+render._withStripped = true
+
+
+
+/***/ }),
+
+/***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/PhotoForm.vue?vue&type=template&id=516c053b&":
+/*!************************************************************************************************************************************************************************************************************!*\
+  !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/PhotoForm.vue?vue&type=template&id=516c053b& ***!
+  \************************************************************************************************************************************************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c(
+    "div",
+    {
+      directives: [
+        {
+          name: "show",
+          rawName: "v-show",
+          value: _vm.value,
+          expression: "value"
+        }
+      ],
+      staticClass: "photo-form"
+    },
+    [
+      _c("h2", { staticClass: "title" }, [_vm._v("Submit a photo")]),
+      _vm._v(" "),
+      _vm._m(0)
+    ]
   )
 }
 var staticRenderFns = [
@@ -3625,9 +3741,16 @@ var staticRenderFns = [
     var _vm = this
     var _h = _vm.$createElement
     var _c = _vm._self._c || _h
-    return _c("button", { staticClass: "button" }, [
-      _c("i", { staticClass: "icon ion-md-add" }),
-      _vm._v("\n        Submit a photo\n      ")
+    return _c("form", { staticClass: "form" }, [
+      _c("input", { staticClass: "form__item", attrs: { type: "file" } }),
+      _vm._v(" "),
+      _c("div", { staticClass: "form__button" }, [
+        _c(
+          "button",
+          { staticClass: "button button--inverse", attrs: { type: "submit" } },
+          [_vm._v("submit")]
+        )
+      ])
     ])
   }
 ]
@@ -20471,6 +20594,75 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Navbar_vue_vue_type_template_id_6dde423b___WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Navbar_vue_vue_type_template_id_6dde423b___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+
+
+
+/***/ }),
+
+/***/ "./resources/js/components/PhotoForm.vue":
+/*!***********************************************!*\
+  !*** ./resources/js/components/PhotoForm.vue ***!
+  \***********************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _PhotoForm_vue_vue_type_template_id_516c053b___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./PhotoForm.vue?vue&type=template&id=516c053b& */ "./resources/js/components/PhotoForm.vue?vue&type=template&id=516c053b&");
+/* harmony import */ var _PhotoForm_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./PhotoForm.vue?vue&type=script&lang=js& */ "./resources/js/components/PhotoForm.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport *//* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+
+
+
+
+
+/* normalize component */
+
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__["default"])(
+  _PhotoForm_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__["default"],
+  _PhotoForm_vue_vue_type_template_id_516c053b___WEBPACK_IMPORTED_MODULE_0__["render"],
+  _PhotoForm_vue_vue_type_template_id_516c053b___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
+  false,
+  null,
+  null,
+  null
+  
+)
+
+/* hot reload */
+if (false) { var api; }
+component.options.__file = "resources/js/components/PhotoForm.vue"
+/* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+
+/***/ "./resources/js/components/PhotoForm.vue?vue&type=script&lang=js&":
+/*!************************************************************************!*\
+  !*** ./resources/js/components/PhotoForm.vue?vue&type=script&lang=js& ***!
+  \************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_PhotoForm_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/babel-loader/lib??ref--4-0!../../../node_modules/vue-loader/lib??vue-loader-options!./PhotoForm.vue?vue&type=script&lang=js& */ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/PhotoForm.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_PhotoForm_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
+
+/***/ }),
+
+/***/ "./resources/js/components/PhotoForm.vue?vue&type=template&id=516c053b&":
+/*!******************************************************************************!*\
+  !*** ./resources/js/components/PhotoForm.vue?vue&type=template&id=516c053b& ***!
+  \******************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_PhotoForm_vue_vue_type_template_id_516c053b___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!../../../node_modules/vue-loader/lib??vue-loader-options!./PhotoForm.vue?vue&type=template&id=516c053b& */ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/PhotoForm.vue?vue&type=template&id=516c053b&");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_PhotoForm_vue_vue_type_template_id_516c053b___WEBPACK_IMPORTED_MODULE_0__["render"]; });
+
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_PhotoForm_vue_vue_type_template_id_516c053b___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -2125,6 +2125,7 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
 /* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../util */ "./resources/js/util.js");
 
 
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
@@ -2147,6 +2148,12 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 //
 //
 //
+//
+//
+//
+//
+//
+
 /* harmony default export */ __webpack_exports__["default"] = ({
   // 親要素(navbar)側で制御を行うためpropsを用いる
   // propsに送られたvalueを参照して小要素(PhotoForm)の内容が決まる
@@ -2162,7 +2169,8 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
     return {
       // previewにはプレビュー画像のデータURLが入る。初期値はnull
       preview: null,
-      photo: null
+      photo: null,
+      errors: null
     };
   },
   methods: {
@@ -2231,16 +2239,37 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
               case 4:
                 response = _context.sent;
 
+                if (!(response.status === _util__WEBPACK_IMPORTED_MODULE_1__["UNPROCESSABLE_ENTITY"])) {
+                  _context.next = 8;
+                  break;
+                }
+
+                _this2.errors = response.data.errors;
+                return _context.abrupt("return", false);
+
+              case 8:
+                // 投稿処理終了時にリセット
                 _this2.reset(); // NavbarのshowFormの値とPhotoFormのinputはv-modelでバインドされている
                 // ここでfalseを返すことで投稿完了時にフォームが閉じる
 
 
-                _this2.$emit('input', false); // 投稿後は詳細ページに画面遷移
+                _this2.$emit('input', false); // responseステータスがCREATEDでない場合はエラー出力
 
 
+                if (!(response.status !== _util__WEBPACK_IMPORTED_MODULE_1__["CREATED"])) {
+                  _context.next = 13;
+                  break;
+                }
+
+                _this2.$store.commit('error/setCode', response.status);
+
+                return _context.abrupt("return", false);
+
+              case 13:
+                // 投稿後は詳細ページに画面遷移
                 _this2.$router.push("/photos/".concat(response.data.id));
 
-              case 8:
+              case 14:
               case "end":
                 return _context.stop();
             }
@@ -3847,6 +3876,20 @@ var render = function() {
           }
         },
         [
+          _vm.errors
+            ? _c("div", { staticClass: "errors" }, [
+                _vm.errors.photo
+                  ? _c(
+                      "ul",
+                      _vm._l(_vm.errors.photo, function(msg) {
+                        return _c("li", { key: msg }, [_vm._v(_vm._s(msg))])
+                      }),
+                      0
+                    )
+                  : _vm._e()
+              ])
+            : _vm._e(),
+          _vm._v(" "),
           _c("input", {
             staticClass: "form__item",
             attrs: { type: "file" },

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=07162e0ef63c00a8e184"
+    "/js/app.js": "/js/app.js?id=5983267d9f82b247f280"
 }

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=669510e57ade6c4f44b8"
+    "/js/app.js": "/js/app.js?id=07162e0ef63c00a8e184"
 }

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=5b54fbc58870d838c5f6"
+    "/js/app.js": "/js/app.js?id=436588d15150e2eafb0f"
 }

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=436588d15150e2eafb0f"
+    "/js/app.js": "/js/app.js?id=a6b1751f013b48c6998e"
 }

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=5983267d9f82b247f280"
+    "/js/app.js": "/js/app.js?id=83b91e870cf847afbb03"
 }

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=7ba1740483f7d8a610d1"
+    "/js/app.js": "/js/app.js?id=a4ae8a6bcd258afe176d"
 }

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=665386cea3a503513faf"
+    "/js/app.js": "/js/app.js?id=5b54fbc58870d838c5f6"
 }

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=a4ae8a6bcd258afe176d"
+    "/js/app.js": "/js/app.js?id=665386cea3a503513faf"
 }

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=a6b1751f013b48c6998e"
+    "/js/app.js": "/js/app.js?id=669510e57ade6c4f44b8"
 }

--- a/src/laravel/resources/js/App.vue
+++ b/src/laravel/resources/js/App.vue
@@ -7,6 +7,7 @@
 
     <main>
       <div class="container">
+        <Message />
         <RouterView />
       </div>
     </main>
@@ -19,6 +20,7 @@
 
 <script>
 
+import Message from './components/Message.vue'
 import Navbar from './components/Navbar'
 import Footer from './components/Footer'
 import { INTERNAL_SERVER_ERROR } from './util'
@@ -26,6 +28,7 @@ import { INTERNAL_SERVER_ERROR } from './util'
 
 export default {
   components: {
+    Message,
     Navbar,
     Footer
   },

--- a/src/laravel/resources/js/components/Loader.vue
+++ b/src/laravel/resources/js/components/Loader.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="loader">
+    <p class="loading__text">
+      <slot>Loading...</slot>
+    </p>
+    <div class="loader__item loader__item--heart"><div></div></div>
+  </div>
+</template>

--- a/src/laravel/resources/js/components/Message.vue
+++ b/src/laravel/resources/js/components/Message.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="message" v-show="message">
+    {{ message }}
+  </div>
+</template>
+
+<script>
+  import { mapState } from 'vuex'
+
+  export default {
+    computed: {
+      ...mapState({
+        message: state => state.message.content
+      })
+    }
+  }
+</script>

--- a/src/laravel/resources/js/components/Navbar.vue
+++ b/src/laravel/resources/js/components/Navbar.vue
@@ -7,7 +7,7 @@
 
     <div class="navbar__menu">
       <div v-if="isLogin" class="navbar__item">
-        <button class="button">
+        <button class="button" @click="showForm = ! showForm">
           <i class="icon ion-md-add"></i>
           Submit a photo
         </button>
@@ -23,11 +23,24 @@
         </RouterLink>
       </div>
     </div>
+    <PhotoForm v-model="showForm" />
   </nav>
 </template>
 
 <script>
+import PhotoForm from './PhotoForm.vue'
+
 export default {
+  components: {
+    PhotoForm
+  },
+  data () {
+    return {
+      // デフォルトではfalseを設定。ボタンを押した際にフォームが表示される
+      showForm: false
+    }
+  },
+
   computed: {
     isLogin () {
       return this.$store.getters['auth/check']

--- a/src/laravel/resources/js/components/PhotoForm.vue
+++ b/src/laravel/resources/js/components/PhotoForm.vue
@@ -133,6 +133,12 @@ export default {
         return false
       }
 
+      // 投稿処理が問題なく完了した場合はメッセージ登録
+      this.$store.commit('message/setContent', {
+        content: '写真が投稿されました！',
+        timeout: 6000
+      })
+
       // 投稿後は詳細ページに画面遷移
       this.$router.push(`/photos/${response.data.id}`)
     }

--- a/src/laravel/resources/js/components/PhotoForm.vue
+++ b/src/laravel/resources/js/components/PhotoForm.vue
@@ -2,7 +2,10 @@
   <div v-show="value" class="photo-form">
     <h2 class="title">Submit a photo</h2>
     <form class="form">
-      <input class="form__item" type="file">
+      <input class="form__item" type="file" @change="onFileChange">
+      <output class="form__output" v-if="preview">
+        <img :src="preview" alt="">
+      </output>
       <div class="form__button">
         <button type="submit" class="button button--inverse">submit</button>
       </div>
@@ -20,6 +23,57 @@ export default {
       type: Boolean,
       // requiredがないとエラーなどで真偽値情報が飛んだ時に動作しなくなる
       required: true
+    }
+  },
+
+  data () {
+    return {
+      // previewにはプレビュー画像のデータURLが入る。初期値はnull
+      preview: null
+    }
+  },
+
+  methods: {
+    // プレビューリセット
+    reset () {
+      // プレビューを消す
+      this.preview = ''
+      // inputデータを消す this.$el.querySelectorはコンポーネントそのもののDOMを探すためのもの
+      this.$el.querySelector('input[type="file"]').value = null
+    },
+
+    // フォームでファイルが選択されたら発火
+    onFileChange (event) {
+      // エラーハンドリング1 何も選択されていなかったら処理中断
+      if (event.target.files.length === 0) {
+        this.reset()
+        return false
+      }
+      // エラーハンドリング2 画像ファイル以外が選択されていたら処理中断
+      if (! event.target.files[0].type.match('image.*')) {
+        this.reset()
+        return false
+      }
+
+      
+      // FileReaderクラスのインスタンスを取得
+      const reader = new FileReader()
+
+
+      // ファイルを読み込み終わったタイミングで実行する処理
+      reader.onload = e => {
+        // previewに読み込み結果（データURL）を代入する
+        // previewに値が入ると<output>につけたv-ifがtrueと判定される
+        // また<output>内部の<img>のsrc属性はpreviewの値を参照しているので
+        // 結果として画像が表示される
+        this.preview = e.target.result
+      }
+
+      // ファイルを読み込む
+      // 読み込まれたファイルはデータURL形式で受け取れる（上記onload参照）
+      reader.readAsDataURL(event.target.files[0])
+
+
     }
   }
 }

--- a/src/laravel/resources/js/components/PhotoForm.vue
+++ b/src/laravel/resources/js/components/PhotoForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="photo-form">
+  <div v-show="value" class="photo-form">
     <h2 class="title">Submit a photo</h2>
     <form class="form">
       <input class="form__item" type="file">
@@ -9,3 +9,18 @@
     </form>
   </div>
 </template>
+
+<script>
+export default {
+  // 親要素(navbar)側で制御を行うためpropsを用いる
+  // propsに送られたvalueを参照して小要素(PhotoForm)の内容が決まる
+  props: {
+    // valueに真偽値を与えることでv-showが機能し、表示/非表示を切り替える
+    value: {
+      type: Boolean,
+      // requiredがないとエラーなどで真偽値情報が飛んだ時に動作しなくなる
+      required: true
+    }
+  }
+}
+</script>

--- a/src/laravel/resources/js/components/PhotoForm.vue
+++ b/src/laravel/resources/js/components/PhotoForm.vue
@@ -94,7 +94,8 @@ export default {
       // NavbarのshowFormの値とPhotoFormのinputはv-modelでバインドされている
       // ここでfalseを返すことで投稿完了時にフォームが閉じる
       this.$emit('input', false)
-
+      // 投稿後は詳細ページに画面遷移
+      this.$router.push(`/photos/${response.data.id}`)
     }
   }
 }

--- a/src/laravel/resources/js/components/PhotoForm.vue
+++ b/src/laravel/resources/js/components/PhotoForm.vue
@@ -1,7 +1,8 @@
 <template>
   <div v-show="value" class="photo-form">
     <h2 class="title">Submit a photo</h2>
-    <form class="form">
+    <!-- .preventはデフォルトの送信処理を抑えるため -->
+    <form class="form" @submit.prevent="submit">>
       <input class="form__item" type="file" @change="onFileChange">
       <output class="form__output" v-if="preview">
         <img :src="preview" alt="">
@@ -29,7 +30,8 @@ export default {
   data () {
     return {
       // previewにはプレビュー画像のデータURLが入る。初期値はnull
-      preview: null
+      preview: null,
+      photo: null
     }
   },
 
@@ -40,6 +42,8 @@ export default {
       this.preview = ''
       // inputデータを消す this.$el.querySelectorはコンポーネントそのもののDOMを探すためのもの
       this.$el.querySelector('input[type="file"]').value = null
+      // 保持していた画像データの情報を消す
+      this.photo = null
     },
 
     // フォームでファイルが選択されたら発火
@@ -73,6 +77,23 @@ export default {
       // 読み込まれたファイルはデータURL形式で受け取れる（上記onload参照）
       reader.readAsDataURL(event.target.files[0])
 
+      // 選択された画像をthis.photoとして保持
+      this.photo = event.target.files[0] 
+    },
+
+    // 送信
+    async submit () {
+      // HTML5のFormDataAPIを使ってAjaxでファイル送信を行う
+      const formData = new FormData()
+      // onFileChangeで保持したデータを代入
+      formData.append('photo', this.photo)
+      // APIを叩く
+      const response = await axios.post('/api/photos', formData)
+
+      this.reset()
+      // NavbarのshowFormの値とPhotoFormのinputはv-modelでバインドされている
+      // ここでfalseを返すことで投稿完了時にフォームが閉じる
+      this.$emit('input', false)
 
     }
   }

--- a/src/laravel/resources/js/components/PhotoForm.vue
+++ b/src/laravel/resources/js/components/PhotoForm.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="photo-form">
+    <h2 class="title">Submit a photo</h2>
+    <form class="form">
+      <input class="form__item" type="file">
+      <div class="form__button">
+        <button type="submit" class="button button--inverse">submit</button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/src/laravel/resources/js/components/PhotoForm.vue
+++ b/src/laravel/resources/js/components/PhotoForm.vue
@@ -1,8 +1,11 @@
 <template>
   <div v-show="value" class="photo-form">
     <h2 class="title">Submit a photo</h2>
+    <div v-show="loading" class="panel">
+      <Loader>Sending your photo...</Loader>
+    </div>
     <!-- .preventはデフォルトの送信処理を抑えるため -->
-    <form class="form" @submit.prevent="submit">
+    <form v-show="! loading" class="form" @submit.prevent="submit">
       <div class="errors" v-if="errors">
         <ul v-if="errors.photo">
           <li v-for="msg in errors.photo" :key="msg">{{ msg }}</li>
@@ -21,8 +24,13 @@
 
 <script>
 import { CREATED, UNPROCESSABLE_ENTITY } from '../util'
+import Loader from './Loader.vue'
 
 export default {
+  components: {
+    Loader
+  },
+
   // 親要素(navbar)側で制御を行うためpropsを用いる
   // propsに送られたvalueを参照して小要素(PhotoForm)の内容が決まる
   props: {
@@ -36,6 +44,8 @@ export default {
 
   data () {
     return {
+      // ロード画面の初期設定は非表示
+      loading: false,
       // previewにはプレビュー画像のデータURLが入る。初期値はnull
       preview: null,
       photo: null,
@@ -91,6 +101,9 @@ export default {
 
     // 送信
     async submit () {
+      // ロード画面を表示
+      this.loading = true
+
       // HTML5のFormDataAPIを使ってAjaxでファイル送信を行う
       const formData = new FormData()
       // onFileChangeで保持したデータを代入
@@ -98,6 +111,8 @@ export default {
 
       // APIを叩く
       const response = await axios.post('/api/photos', formData)
+
+      this.loading = false
 
       // バリデーションエラーの場合はreturn falseで処理自体を中断
       // 入力されたフォーム内容は保持したままエラーメッセージの取得に進む

--- a/src/laravel/resources/js/components/PhotoForm.vue
+++ b/src/laravel/resources/js/components/PhotoForm.vue
@@ -2,7 +2,7 @@
   <div v-show="value" class="photo-form">
     <h2 class="title">Submit a photo</h2>
     <!-- .preventはデフォルトの送信処理を抑えるため -->
-    <form class="form" @submit.prevent="submit">>
+    <form class="form" @submit.prevent="submit">
       <input class="form__item" type="file" @change="onFileChange">
       <output class="form__output" v-if="preview">
         <img :src="preview" alt="">

--- a/src/laravel/resources/js/pages/PhotoDetail.vue
+++ b/src/laravel/resources/js/pages/PhotoDetail.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>Photo Detail</h1>
+</template>

--- a/src/laravel/resources/js/router.js
+++ b/src/laravel/resources/js/router.js
@@ -5,6 +5,7 @@ import VueRouter from 'vue-router'
 import PhotoList from './pages/PhotoList.vue'
 import Login from './pages/Login.vue'
 import SystemError from './pages/errors/System.vue'
+import PhotoDetail from './pages/PhotoDetail.vue'
 
 import store from './store'
 

--- a/src/laravel/resources/js/router.js
+++ b/src/laravel/resources/js/router.js
@@ -19,6 +19,11 @@ const routes = [
     component: PhotoList
   },
   {
+    path: '/photos/:id',
+    component: PhotoDetail,
+    props: true
+  },
+  {
     path: '/login',
     component: Login,
     beforeEnter(to, from, next) {

--- a/src/laravel/resources/js/store/index.js
+++ b/src/laravel/resources/js/store/index.js
@@ -4,6 +4,7 @@ import Vuex from 'vuex'
 // ストア読み込み
 import auth from './auth'
 import error from './error'
+import message from './message'
 
 
 Vue.use(Vuex)
@@ -11,7 +12,8 @@ Vue.use(Vuex)
 const store = new Vuex.Store({
   modules: {
     auth,
-    error
+    error,
+    message
   }
 })
 

--- a/src/laravel/resources/js/store/message.js
+++ b/src/laravel/resources/js/store/message.js
@@ -1,0 +1,22 @@
+const state = {
+  content: ''
+}
+
+const mutations = {
+  setContent(state, { content, timeout }) {
+    state.content = content
+
+    if (typeof timeout === 'undefined') {
+      timeout = 3000
+    }
+
+    // メッセージがタイムアウトを過ぎると自動で消去される
+    setTimeout(() => (state.content = ''), timeout)
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  mutations
+}


### PR DESCRIPTION
# WHAT
- 写真投稿フォーム作成
  - ボタンクリックで表示/非表示の切り替えができる
    - v-modelで親子要素をバインドしステータスの変更をpropsで管理することで親要素から制御を行う

- ファイルプレビュー作成
  - 非同期でプレビュー表示ができるように親要素から制御を行う
  - プレビューの表示にはHTML5のFileReaderAPIを使用

- ファイル送信機能実装
  - 送信機能ではFormDataAPIを使って送信を行う

- ローディング画面作成
  - ローダーコンポーネントを新規作成
    - PhotoFormコンポーネントでインポートしてロード中に表示を切り替えて使う

- 送信成功画面作成
  - コンポーネントを跨いでメッセージ管理を行うため新規でmessageストアを作成
    - PhotoFormコンポーネントで送信成功時にmessageストアを書き換えてvuexで監視と差込を行う

- エラーハンドリング
  - ログインや会員登録同様にerrorストアを用いてバリデーションチェックを行う
    
