### PR TITLE
写真詳細ページ実装

### DIFF
--- a/src/laravel/app/Http/Controllers/PhotoController.php
+++ b/src/laravel/app/Http/Controllers/PhotoController.php
@@ -16,7 +16,7 @@ class PhotoController extends Controller
          * 画像保存関連は認証が必要
          * 画像一覧表示に関しては認証を必要としないためexceptで回避させる
          */
-        $this->middleware('auth')->except(['index', 'download']);
+        $this->middleware('auth')->except(['index', 'download', 'show']);
     }
 
 
@@ -99,5 +99,17 @@ class PhotoController extends Controller
         ];
 
         return response(Storage::cloud()->get($photo->filename), 200, $headers);
+    }
+
+    /**
+     * 写真詳細
+     * @param string $id
+     * @return Photo
+     */
+    public function show(string $id)
+    {
+        $photo = Photo::where('id', $id)->with(['owner'])->first();
+
+        return $photo ?? abort(404);
     }
 }

--- a/src/laravel/app/Photo.php
+++ b/src/laravel/app/Photo.php
@@ -28,7 +28,7 @@ class Photo extends Model
     ];
 
     // ページネーションの１ページあたりの表示件数
-    protected $perPage = 2;
+    protected $perPage = 5;
 
 
 

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -2689,6 +2689,12 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 //
 //
 //
+//
+//
+//
+//
+//
+//
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   props: {
@@ -2699,7 +2705,9 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
   },
   data: function data() {
     return {
-      photo: null
+      photo: null,
+      // @clickでバインドされたクラスを付け替える
+      fullWidth: false
     };
   },
   methods: {
@@ -4969,34 +4977,56 @@ var render = function() {
   var _vm = this
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
-  return _c("div", { staticClass: "panel-detail" }, [
-    _c("figure", { staticClass: "photo-detail__pane photo-detail__image" }, [
-      _c("img", { attrs: { src: _vm.photo.url, alt: "" } }),
-      _vm._v(" "),
-      _c("figcaption", [_vm._v("Posted by " + _vm._s(_vm.photo.owner.name))])
-    ]),
-    _vm._v(" "),
-    _c("div", { staticClass: "photo-detail__pane" }, [
-      _vm._m(0),
-      _vm._v(" "),
-      _c(
-        "a",
+  return _vm.photo
+    ? _c(
+        "div",
         {
-          staticClass: "button",
-          attrs: {
-            href: "/photos/" + _vm.photo.id + "/download",
-            title: "Download photo"
-          }
+          staticClass: "photo-detail",
+          class: { "photo-detail--column": _vm.fullWidth }
         },
         [
-          _c("i", { staticClass: "icon ion-md-arrow-round-down" }),
-          _vm._v("Download\n    ")
+          _c(
+            "figure",
+            {
+              staticClass: "photo-detail__pane photo-detail__image",
+              on: {
+                click: function($event) {
+                  _vm.fullWidth = !_vm.fullWidth
+                }
+              }
+            },
+            [
+              _c("img", { attrs: { src: _vm.photo.url, alt: "" } }),
+              _vm._v(" "),
+              _c("figcaption", [
+                _vm._v("Posted by " + _vm._s(_vm.photo.owner.name))
+              ])
+            ]
+          ),
+          _vm._v(" "),
+          _c("div", { staticClass: "photo-detail__pane" }, [
+            _vm._m(0),
+            _vm._v(" "),
+            _c(
+              "a",
+              {
+                staticClass: "button",
+                attrs: {
+                  href: "/photos/" + _vm.photo.id + "/download",
+                  title: "Download photo"
+                }
+              },
+              [
+                _c("i", { staticClass: "icon ion-md-arrow-round-down" }),
+                _vm._v("Download\n    ")
+              ]
+            ),
+            _vm._v(" "),
+            _vm._m(1)
+          ])
         ]
-      ),
-      _vm._v(" "),
-      _vm._m(1)
-    ])
-  ])
+      )
+    : _vm._e()
 }
 var staticRenderFns = [
   function() {

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -2647,6 +2647,130 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
 
 /***/ }),
 
+/***/ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/pages/PhotoDetail.vue?vue&type=script&lang=js&":
+/*!*****************************************************************************************************************************************************************!*\
+  !*** ./node_modules/babel-loader/lib??ref--4-0!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/pages/PhotoDetail.vue?vue&type=script&lang=js& ***!
+  \*****************************************************************************************************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/regenerator */ "./node_modules/@babel/runtime/regenerator/index.js");
+/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _util__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../util */ "./resources/js/util.js");
+
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  props: {
+    id: {
+      type: String,
+      required: true
+    }
+  },
+  data: function data() {
+    return {
+      photo: null
+    };
+  },
+  methods: {
+    fetchPhoto: function fetchPhoto() {
+      var _this = this;
+
+      return _asyncToGenerator(
+      /*#__PURE__*/
+      _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee() {
+        var response;
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                _context.next = 2;
+                return axios.get("/api/photos/".concat(_this.id));
+
+              case 2:
+                response = _context.sent;
+
+                if (!(response.status !== _util__WEBPACK_IMPORTED_MODULE_1__["OK"])) {
+                  _context.next = 6;
+                  break;
+                }
+
+                _this.$store.commit('error/setCode', response.status);
+
+                return _context.abrupt("return", false);
+
+              case 6:
+                _this.photo = response.data;
+
+              case 7:
+              case "end":
+                return _context.stop();
+            }
+          }
+        }, _callee);
+      }))();
+    }
+  },
+  watch: {
+    $route: {
+      handler: function handler() {
+        var _this2 = this;
+
+        return _asyncToGenerator(
+        /*#__PURE__*/
+        _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee2() {
+          return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee2$(_context2) {
+            while (1) {
+              switch (_context2.prev = _context2.next) {
+                case 0:
+                  _context2.next = 2;
+                  return _this2.fetchPhoto();
+
+                case 2:
+                case "end":
+                  return _context2.stop();
+              }
+            }
+          }, _callee2);
+        }))();
+      },
+      immediate: true
+    }
+  }
+});
+
+/***/ }),
+
 /***/ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/pages/PhotoList.vue?vue&type=script&lang=js&":
 /*!***************************************************************************************************************************************************************!*\
   !*** ./node_modules/babel-loader/lib??ref--4-0!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/pages/PhotoList.vue?vue&type=script&lang=js& ***!
@@ -4845,9 +4969,56 @@ var render = function() {
   var _vm = this
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
-  return _c("h1", [_vm._v("Photo Detail")])
+  return _c("div", { staticClass: "panel-detail" }, [
+    _c("figure", { staticClass: "photo-detail__pane photo-detail__image" }, [
+      _c("img", { attrs: { src: _vm.photo.url, alt: "" } }),
+      _vm._v(" "),
+      _c("figcaption", [_vm._v("Posted by " + _vm._s(_vm.photo.owner.name))])
+    ]),
+    _vm._v(" "),
+    _c("div", { staticClass: "photo-detail__pane" }, [
+      _vm._m(0),
+      _vm._v(" "),
+      _c(
+        "a",
+        {
+          staticClass: "button",
+          attrs: {
+            href: "/photos/" + _vm.photo.id + "/download",
+            title: "Download photo"
+          }
+        },
+        [
+          _c("i", { staticClass: "icon ion-md-arrow-round-down" }),
+          _vm._v("Download\n    ")
+        ]
+      ),
+      _vm._v(" "),
+      _vm._m(1)
+    ])
+  ])
 }
-var staticRenderFns = []
+var staticRenderFns = [
+  function() {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c(
+      "button",
+      { staticClass: "button button--like", attrs: { title: "Like Photo" } },
+      [_c("i", { staticClass: "icon ion-md-heart" }), _vm._v("12\n    ")]
+    )
+  },
+  function() {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("h2", { staticClass: "photo-detail__title" }, [
+      _c("i", { staticClass: "icon ion-md-chatboxes" }),
+      _vm._v("Comments\n    ")
+    ])
+  }
+]
 render._withStripped = true
 
 
@@ -21770,15 +21941,17 @@ __webpack_require__.r(__webpack_exports__);
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _PhotoDetail_vue_vue_type_template_id_c17cd6ac___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./PhotoDetail.vue?vue&type=template&id=c17cd6ac& */ "./resources/js/pages/PhotoDetail.vue?vue&type=template&id=c17cd6ac&");
-/* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+/* harmony import */ var _PhotoDetail_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./PhotoDetail.vue?vue&type=script&lang=js& */ "./resources/js/pages/PhotoDetail.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport *//* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
 
-var script = {}
+
+
 
 
 /* normalize component */
 
-var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_1__["default"])(
-  script,
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__["default"])(
+  _PhotoDetail_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__["default"],
   _PhotoDetail_vue_vue_type_template_id_c17cd6ac___WEBPACK_IMPORTED_MODULE_0__["render"],
   _PhotoDetail_vue_vue_type_template_id_c17cd6ac___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
   false,
@@ -21792,6 +21965,20 @@ var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_
 if (false) { var api; }
 component.options.__file = "resources/js/pages/PhotoDetail.vue"
 /* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+
+/***/ "./resources/js/pages/PhotoDetail.vue?vue&type=script&lang=js&":
+/*!*********************************************************************!*\
+  !*** ./resources/js/pages/PhotoDetail.vue?vue&type=script&lang=js& ***!
+  \*********************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_PhotoDetail_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/babel-loader/lib??ref--4-0!../../../node_modules/vue-loader/lib??vue-loader-options!./PhotoDetail.vue?vue&type=script&lang=js& */ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/pages/PhotoDetail.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_PhotoDetail_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
 
 /***/ }),
 
@@ -21976,6 +22163,7 @@ var routes = [{
 }, {
   path: '/photos/:id',
   component: _pages_PhotoDetail_vue__WEBPACK_IMPORTED_MODULE_5__["default"],
+  // ルートコンポーネントにプロパティを渡す
   props: true
 }, {
   path: '/login',

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=419437fc6e65034d5efb"
+    "/js/app.js": "/js/app.js?id=a23955a006ba1d8ec439"
 }

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=a23955a006ba1d8ec439"
+    "/js/app.js": "/js/app.js?id=056636ff2537dfa3a213"
 }

--- a/src/laravel/resources/js/pages/PhotoDetail.vue
+++ b/src/laravel/resources/js/pages/PhotoDetail.vue
@@ -1,6 +1,12 @@
 <template>
-  <div class="panel-detail">
-    <figure class="photo-detail__pane photo-detail__image">
+  <!-- :classはv-bind:classの省略形 -->
+  <div 
+    v-if="photo" 
+    class="photo-detail"
+    :class="{ 'photo-detail--column': fullWidth }"> 
+    <figure 
+      class="photo-detail__pane photo-detail__image"
+      @click="fullWidth = ! fullWidth">
       <img :src="photo.url" alt="">
       <figcaption>Posted by {{ photo.owner.name }}</figcaption>
     </figure>
@@ -34,7 +40,9 @@ export default {
   },
   data () {
     return {
-      photo: null
+      photo: null,
+      // @clickでバインドされたクラスを付け替える
+      fullWidth: false
     }
   },
   methods:{

--- a/src/laravel/resources/js/pages/PhotoDetail.vue
+++ b/src/laravel/resources/js/pages/PhotoDetail.vue
@@ -1,3 +1,61 @@
 <template>
-  <h1>Photo Detail</h1>
+  <div class="panel-detail">
+    <figure class="photo-detail__pane photo-detail__image">
+      <img :src="photo.url" alt="">
+      <figcaption>Posted by {{ photo.owner.name }}</figcaption>
+    </figure>
+    <div class="photo-detail__pane">
+      <button class="button button--like" title="Like Photo">
+        <i class="icon ion-md-heart"></i>12
+      </button>
+      <a
+        :href="`/photos/${photo.id}/download`"
+        class="button"
+        title="Download photo"
+      >
+        <i class="icon ion-md-arrow-round-down"></i>Download
+      </a>
+      <h2 class="photo-detail__title">
+        <i class="icon ion-md-chatboxes"></i>Comments
+      </h2>
+    </div>
+  </div>
 </template>
+
+<script>
+import { OK } from '../util'
+
+export default {
+  props:{
+    id: {
+      type: String,
+      required: true
+    }
+  },
+  data () {
+    return {
+      photo: null
+    }
+  },
+  methods:{
+    async fetchPhoto () {
+      const response = await axios.get(`/api/photos/${this.id}`)
+
+      if (response.status !== OK) {
+        this.$store.commit('error/setCode', response.status)
+        return false
+      }
+
+      this.photo = response.data
+    }
+  },
+  watch:{
+    $route: {
+      async handler () {
+        await this.fetchPhoto()
+      },
+      immediate: true
+    }
+  }
+}
+</script>

--- a/src/laravel/resources/js/router.js
+++ b/src/laravel/resources/js/router.js
@@ -26,6 +26,7 @@ const routes = [
   {
     path: '/photos/:id',
     component: PhotoDetail,
+    // ルートコンポーネントにプロパティを渡す
     props: true
   },
   {

--- a/src/laravel/routes/api.php
+++ b/src/laravel/routes/api.php
@@ -20,6 +20,9 @@ Route::post('/photos', 'PhotoController@create')->name('photo.create');
 // 写真一覧
 Route::get('/photos', 'PhotoController@index')->name('photo.index');
 
+// 写真詳細
+Route::get('/photos/{id}', 'PhotoController@show')->name('photo.show');
+
 
 
 // Route::middleware('auth:api')->get('/user', function (Request $request) {

--- a/src/laravel/tests/Feature/PhotoDetailApiTest.php
+++ b/src/laravel/tests/Feature/PhotoDetailApiTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Photo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class PhotoDetailApiTest extends TestCase
+{
+    use RefreshDatabase;
+    /** 
+     * @test
+     */ 
+    public function should__正しい構造のJsonを取得する()
+    {
+        factory(Photo::class)->create();
+        $photo = Photo::first();
+
+        $response = $this->json('GET', route('photo.show', [
+            'id' => $photo->id,
+        ]));
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'id' => $photo->id,
+                'url' => $photo->url,
+                'owner' => [
+                    'name' => $photo->owner->name,
+                ],
+            ]);
+    }
+}


### PR DESCRIPTION
# WHAT
- PhotoDetailApiテスト作成
  - 写真一覧から渡されたプロパティ(photo id)を使ってAPIを叩いて写真データが取得できるかテスト
  - 取得された写真データにはid/url/ownerが紐づいているかテスト

- PhotoDetailビュー作成
  - 写真、オーナー情報、ダウンロードボタン、いいねボタンの設置
  - fullWidthクラス作成
    - 写真がクリックされた時にクラスの付け替えが行われ写真の横幅が最大表示になる
    - cssでflex-directionをrowからcolumnに切り替えることでコメント欄などの表示を切り替えている