### PR TITLE
いいね機能実装

### DIFF
--- a/src/laravel/app/Http/Controllers/PhotoController.php
+++ b/src/laravel/app/Http/Controllers/PhotoController.php
@@ -133,4 +133,46 @@ class PhotoController extends Controller
 
         return response($new_comment, 201);
     }
+
+    /**
+     * いいね
+     * @param string $id
+     * @return array
+     */
+    public function like(string $id)
+    {
+        // photosテーブルのidカラムを引数で渡された$idで参照しリレーションで関連づけられたlikesテーブルの情報も合わせて引き出す
+        $photo = Photo::where('id', $id)->with('likes')->first();
+
+        if (!$photo) {
+            abort(404);
+        }
+
+        /**
+         * いいねは1回しかつけられないようにする仕様
+         * 特定の写真及び、ログインユーザーにひもづくいいねを削除してから新たに追加する */ 
+        $photo->likes()->detach(Auth::user()->id);
+        $photo->likes()->attach(Auth::user()->id);
+
+        return ["photo_id" => $id];
+    }
+
+
+    /**
+     * いいね解除
+     * @param string $id
+     * @return array
+     */
+    public function unlike(string $id)
+    {
+        $photo = Photo::where('id', $id)->with('likes')->first();
+
+        if (!$photo) {
+            abort(404);
+        }
+
+        $photo->likes()->detach(Auth::user()->id);
+
+        return ["photo_id" => $id];
+    }
 }

--- a/src/laravel/app/Http/Controllers/PhotoController.php
+++ b/src/laravel/app/Http/Controllers/PhotoController.php
@@ -69,7 +69,7 @@ class PhotoController extends Controller
          * foreachなどでループ処理させる際に都度SQLを発行すると処理が遅くなるN＋1問題を回避するために用いる
          * paginate()メソッドはgetメソッド＋ページ送り機能がついた取得メソッド
          */
-        $photos = Photo::with(['owner'])
+        $photos = Photo::with(['owner', 'likes'])
             ->orderBy(Photo::CREATED_AT, 'desc')->paginate();
 
         /**
@@ -111,7 +111,7 @@ class PhotoController extends Controller
     public function show(string $id)
     {
         // commments.authorのようにプロパティに.リレーション名でそれにひもづくデータを取得できる
-        $photo = Photo::where('id', $id)->with(['owner', 'comments.author'])->first();
+        $photo = Photo::where('id', $id)->with(['owner', 'comments.author', 'likes'])->first();
 
         return $photo ?? abort(404);
     }

--- a/src/laravel/app/Photo.php
+++ b/src/laravel/app/Photo.php
@@ -113,4 +113,13 @@ class Photo extends Model
     {
         return Storage::cloud()->url($this->attributes['filename']);
     }
+
+    /**
+     * アクセサ - likes_count
+     * @return int
+     */
+    public function getLikesCountAttribute()
+    {
+        return $this->likes->count();
+    }
 }

--- a/src/laravel/app/Photo.php
+++ b/src/laravel/app/Photo.php
@@ -90,6 +90,18 @@ class Photo extends Model
     public function comments () {
         return $this->hasMany('App\Comment')->orderBy('id', 'desc');
     }
+
+    /**
+     * リレーションシップ - usersテーブル
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function likes()
+    {
+        /** likesテーブルを中間テーブルとしてphotosテーブルとuserテーブルを多対多で関連づける
+         * ->withTimestamps()はlikesテーブルにデータが挿入された時にcreated_at,updated_atを更新するため
+         */
+        return $this->belongsToMany('App\User', 'likes')->withTimestamps();
+    }
     
     /**
      * ユーザー定義のアクセサ - url

--- a/src/laravel/app/Photo.php
+++ b/src/laravel/app/Photo.php
@@ -5,6 +5,7 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Auth;
 
 
 class Photo extends Model
@@ -16,15 +17,15 @@ class Photo extends Model
      * 余計な項目(user_id, filename)を表示しない
      */
     protected $visible = [
-        'id', 'owner', 'url', 'comments'
+        'id', 'owner', 'url', 'comments', 'likes_count', 'liked_by_user',
     ];
 
     /** 
-     * JSONに含める属性
+     * JSONに含めるアクセサ
      * アクセサで定義した内容で実際にJSONとして反映させる項目
      */
     protected $appends = [
-        'url',
+        'url', 'likes_count', 'liked_by_user',
     ];
 
     // ページネーションの１ページあたりの表示件数
@@ -122,4 +123,20 @@ class Photo extends Model
     {
         return $this->likes->count();
     }
+
+    /**
+     * アクセサ - liked_by_user
+     * @return boolean
+     */
+    public function getLikedByUserAttribute()
+    {
+        if (Auth::guest()) {
+            return false;
+        }
+        // コレクションメソッドを使ってログインユーザーのIDと合致するいいねが含まれるか調べる
+        return $this->likes->contains(function ($user) {
+            return $user->id === Auth::user()->id;
+        });
+    }
+
 }

--- a/src/laravel/public/js/app.js
+++ b/src/laravel/public/js/app.js
@@ -2260,11 +2260,24 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 //
+//
+//
+//
+//
+// PhotoList->Photo.vueの階層構造を持つ
 /* harmony default export */ __webpack_exports__["default"] = ({
   props: {
     item: {
       type: Object,
       required: true
+    }
+  },
+  methods: {
+    like: function like() {
+      this.$emit('like', {
+        id: this.item.id,
+        liked: this.item.liked_by_user
+      });
     }
   }
 });
@@ -2725,6 +2738,11 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 //
 //
 //
+//
+//
+//
+//
+//
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   props: {
@@ -2832,29 +2850,117 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
           }
         }, _callee2);
       }))();
+    },
+    onLikeClick: function onLikeClick() {
+      if (!this.isLogin) {
+        alert('いいね機能を使うにはログインしてください。');
+        return false;
+      }
+
+      if (this.photo.liked_by_user) {
+        this.unlike();
+      } else {
+        this.like();
+      }
+    },
+    like: function like() {
+      var _this3 = this;
+
+      return _asyncToGenerator(
+      /*#__PURE__*/
+      _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee3() {
+        var response;
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee3$(_context3) {
+          while (1) {
+            switch (_context3.prev = _context3.next) {
+              case 0:
+                _context3.next = 2;
+                return axios.put("api/photos/".concat(_this3.id, "/like"));
+
+              case 2:
+                response = _context3.sent;
+
+                if (!(response.status !== _util__WEBPACK_IMPORTED_MODULE_1__["OK"])) {
+                  _context3.next = 6;
+                  break;
+                }
+
+                _this3.$store.commit('error/setCode', response.status);
+
+                return _context3.abrupt("return", false);
+
+              case 6:
+                _this3.photo.likes_count = _this3.photo.likes_count + 1;
+                _this3.photo.liked_by_user = true;
+
+              case 8:
+              case "end":
+                return _context3.stop();
+            }
+          }
+        }, _callee3);
+      }))();
+    },
+    unlike: function unlike() {
+      var _this4 = this;
+
+      return _asyncToGenerator(
+      /*#__PURE__*/
+      _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee4() {
+        var response;
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee4$(_context4) {
+          while (1) {
+            switch (_context4.prev = _context4.next) {
+              case 0:
+                _context4.next = 2;
+                return axios["delete"]("api/photos/".concat(_this4.id, "/like"));
+
+              case 2:
+                response = _context4.sent;
+
+                if (!(response.status !== _util__WEBPACK_IMPORTED_MODULE_1__["OK"])) {
+                  _context4.next = 6;
+                  break;
+                }
+
+                _this4.$store.commit('error/setCode', response.status);
+
+                return _context4.abrupt("return", false);
+
+              case 6:
+                _this4.photo.likes_count = _this4.photo.likes_count - 1;
+                _this4.photo.liked_by_user = false;
+
+              case 8:
+              case "end":
+                return _context4.stop();
+            }
+          }
+        }, _callee4);
+      }))();
     }
   },
   watch: {
     $route: {
       handler: function handler() {
-        var _this3 = this;
+        var _this5 = this;
 
         return _asyncToGenerator(
         /*#__PURE__*/
-        _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee3() {
-          return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee3$(_context3) {
+        _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee5() {
+          return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee5$(_context5) {
             while (1) {
-              switch (_context3.prev = _context3.next) {
+              switch (_context5.prev = _context5.next) {
                 case 0:
-                  _context3.next = 2;
-                  return _this3.fetchPhoto();
+                  _context5.next = 2;
+                  return _this5.fetchPhoto();
 
                 case 2:
                 case "end":
-                  return _context3.stop();
+                  return _context5.stop();
               }
             }
-          }, _callee3);
+          }, _callee5);
         }))();
       },
       immediate: true
@@ -2889,6 +2995,7 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
+//
 //
 //
 //
@@ -2965,29 +3072,134 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
           }
         }, _callee);
       }))();
+    },
+    // photo.vueのいいねボタンから送られてきたemitが引数に入る
+    onLikeClick: function onLikeClick(_ref) {
+      var id = _ref.id,
+          liked = _ref.liked;
+
+      if (!this.$store.getters['auth/check']) {
+        alert('いいね機能を使うにはログインしてください。');
+        return false;
+      } // いいねがすでにされていた場合とそうでない場合の分岐
+
+
+      if (liked) {
+        this.unlike(id);
+      } else {
+        this.like(id);
+      }
+    },
+    like: function like(id) {
+      var _this2 = this;
+
+      return _asyncToGenerator(
+      /*#__PURE__*/
+      _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee2() {
+        var response;
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee2$(_context2) {
+          while (1) {
+            switch (_context2.prev = _context2.next) {
+              case 0:
+                _context2.next = 2;
+                return axios.put("/api/photos/".concat(id, "/like"));
+
+              case 2:
+                response = _context2.sent;
+
+                if (!(response.status !== _util__WEBPACK_IMPORTED_MODULE_1__["OK"])) {
+                  _context2.next = 6;
+                  break;
+                }
+
+                _this2.$store.commit('error/setCode', response.status);
+
+                return _context2.abrupt("return", false);
+
+              case 6:
+                // いいねがつけられた際のフロント画面の更新
+                _this2.photos = _this2.photos.map(function (photo) {
+                  if (photo.id === response.data.photo_id) {
+                    photo.likes_count += 1, photo.liked_by_user = true;
+                  }
+
+                  return photo;
+                });
+
+              case 7:
+              case "end":
+                return _context2.stop();
+            }
+          }
+        }, _callee2);
+      }))();
+    },
+    unlike: function unlike(id) {
+      var _this3 = this;
+
+      return _asyncToGenerator(
+      /*#__PURE__*/
+      _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee3() {
+        var response;
+        return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee3$(_context3) {
+          while (1) {
+            switch (_context3.prev = _context3.next) {
+              case 0:
+                _context3.next = 2;
+                return axios["delete"]("/api/photos/".concat(id, "/like"));
+
+              case 2:
+                response = _context3.sent;
+
+                if (!(response.status !== _util__WEBPACK_IMPORTED_MODULE_1__["OK"])) {
+                  _context3.next = 6;
+                  break;
+                }
+
+                _this3.$store.commit('error/setCode', response.status);
+
+                return _context3.abrupt("return", false);
+
+              case 6:
+                // いいねが取り消された際のフロント画面の更新
+                _this3.photos = _this3.photos.map(function (photo) {
+                  if (photo.id === response.data.photo_id) {
+                    photo.likes_count -= 1, photo.liked_by_user = false;
+                  }
+
+                  return photo;
+                });
+
+              case 7:
+              case "end":
+                return _context3.stop();
+            }
+          }
+        }, _callee3);
+      }))();
     }
   },
   watch: {
     $route: {
       handler: function handler() {
-        var _this2 = this;
+        var _this4 = this;
 
         return _asyncToGenerator(
         /*#__PURE__*/
-        _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee2() {
-          return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee2$(_context2) {
+        _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.mark(function _callee4() {
+          return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_0___default.a.wrap(function _callee4$(_context4) {
             while (1) {
-              switch (_context2.prev = _context2.next) {
+              switch (_context4.prev = _context4.next) {
                 case 0:
-                  _context2.next = 2;
-                  return _this2.fetchPhotos();
+                  _context4.next = 2;
+                  return _this4.fetchPhotos();
 
                 case 2:
                 case "end":
-                  return _context2.stop();
+                  return _context4.stop();
               }
             }
-          }, _callee2);
+          }, _callee4);
         }))();
       },
       immediate: true
@@ -4537,11 +4749,18 @@ var render = function() {
               "button",
               {
                 staticClass: "photo__action photo__action--like",
-                attrs: { title: "Like photo" }
+                class: { "photo__action--liked": _vm.item.liked_by_user },
+                attrs: { title: "Like photo" },
+                on: {
+                  click: function($event) {
+                    $event.preventDefault()
+                    return _vm.like($event)
+                  }
+                }
               },
               [
                 _c("i", { staticClass: "icon ion-md-heart" }),
-                _vm._v("12\n      ")
+                _vm._v(_vm._s(_vm.item.likes_count) + "\n      ")
               ]
             ),
             _vm._v(" "),
@@ -5095,7 +5314,19 @@ var render = function() {
           ),
           _vm._v(" "),
           _c("div", { staticClass: "photo-detail__pane" }, [
-            _vm._m(0),
+            _c(
+              "button",
+              {
+                staticClass: "button button--like",
+                class: { "button--liked": _vm.photo.liked_by_user },
+                attrs: { title: "Like Photo" },
+                on: { click: _vm.onLikeClick }
+              },
+              [
+                _c("i", { staticClass: "icon ion-md-heart" }),
+                _vm._v(_vm._s(_vm.photo.likes_count) + "\n    ")
+              ]
+            ),
             _vm._v(" "),
             _c(
               "a",
@@ -5112,7 +5343,7 @@ var render = function() {
               ]
             ),
             _vm._v(" "),
-            _vm._m(1),
+            _vm._m(0),
             _vm._v(" "),
             _vm.photo.comments.length > 0
               ? _c(
@@ -5192,7 +5423,7 @@ var render = function() {
                       }
                     }),
                     _vm._v(" "),
-                    _vm._m(2)
+                    _vm._m(1)
                   ]
                 )
               : _vm._e()
@@ -5202,16 +5433,6 @@ var render = function() {
     : _vm._e()
 }
 var staticRenderFns = [
-  function() {
-    var _vm = this
-    var _h = _vm.$createElement
-    var _c = _vm._self._c || _h
-    return _c(
-      "button",
-      { staticClass: "button button--like", attrs: { title: "Like Photo" } },
-      [_c("i", { staticClass: "icon ion-md-heart" }), _vm._v("12\n    ")]
-    )
-  },
   function() {
     var _vm = this
     var _h = _vm.$createElement
@@ -5266,7 +5487,8 @@ var render = function() {
           return _c("Photo", {
             key: photo.id,
             staticClass: "grid__item",
-            attrs: { item: photo }
+            attrs: { item: photo },
+            on: { like: _vm.onLikeClick }
           })
         }),
         1

--- a/src/laravel/public/mix-manifest.json
+++ b/src/laravel/public/mix-manifest.json
@@ -1,3 +1,3 @@
 {
-    "/js/app.js": "/js/app.js?id=4ac6321e683c968b7255"
+    "/js/app.js": "/js/app.js?id=cd15117ce6f277ac46d2"
 }

--- a/src/laravel/resources/js/components/Photo.vue
+++ b/src/laravel/resources/js/components/Photo.vue
@@ -49,6 +49,7 @@
 </template>
 
 <script>
+// PhotoList->Photo.vueの階層構造を持つ
 export default {
   props: {
     item: {

--- a/src/laravel/resources/js/components/Photo.vue
+++ b/src/laravel/resources/js/components/Photo.vue
@@ -15,12 +15,16 @@
       :title="`View the photo by ${item.owner.name}`"
     >
       <!-- like button & download link-->
+      <!-- :classはいいねがすでにいいねがついている場合に付与するクラス -->
+      <!-- @clickイベントでlikeメソッドを呼び出していいね状態を切り替える -->
       <div class="photo__controls">
         <button
           class="photo__action photo__action--like"
+          :class="{ 'photo__action--liked': item.liked_by_user }"
           title="Like photo"
+          @click.prevent="like"
         >
-          <i class="icon ion-md-heart"></i>12
+          <i class="icon ion-md-heart"></i>{{ item.likes_count }}
         </button>
 
         <!-- ダウンロード昨日はvueのRouterLinkではなくサーバー再度で行うためaタグで用意する必要がある -->
@@ -51,6 +55,16 @@ export default {
       type: Object,
       required: true
     }
+  },
+
+  methods: {
+    like () {
+      this.$emit('like', {
+        id: this.item.id,
+        liked: this.item.liked_by_user,
+      })
+    }
   }
 }
 </script>
+

--- a/src/laravel/resources/js/pages/PhotoDetail.vue
+++ b/src/laravel/resources/js/pages/PhotoDetail.vue
@@ -11,8 +11,13 @@
       <figcaption>Posted by {{ photo.owner.name }}</figcaption>
     </figure>
     <div class="photo-detail__pane">
-      <button class="button button--like" title="Like Photo">
-        <i class="icon ion-md-heart"></i>12
+      <button
+        class="button button--like"
+        :class="{ 'button--liked': photo.liked_by_user }"
+        title="Like Photo"
+        @click="onLikeClick"
+      >
+        <i class="icon ion-md-heart"></i>{{ photo.likes_count }}
       </button>
       <a
         :href="`/photos/${photo.id}/download`"
@@ -106,7 +111,44 @@ export default {
         response.data,
         ...this.photo.comments
       ]
-    }
+    },
+    onLikeClick () {
+      if (! this.isLogin) {
+        alert('いいね機能を使うにはログインしてください。')
+        return false
+      }
+
+      if (this.photo.liked_by_user) {
+        this.unlike()
+      } else {
+        this.like()
+      }
+    },
+
+    async like () {
+      const response = await axios.put(`api/photos/${this.id}/like`)
+
+      if (response.status !== OK) {
+        this.$store.commit('error/setCode', response.status)
+        return false
+      }
+
+      this.photo.likes_count = this.photo.likes_count + 1
+      this.photo.liked_by_user = true
+    },
+
+    async unlike () {
+      const response = await axios.delete(`api/photos/${this.id}/like`)
+
+      if (response.status !== OK) {
+        this.$store.commit('error/setCode', response.status)
+        return false
+      }
+
+      this.photo.likes_count = this.photo.likes_count - 1
+      this.photo.liked_by_user = false
+    },
+
   },
   watch:{
     $route: {

--- a/src/laravel/resources/js/pages/PhotoList.vue
+++ b/src/laravel/resources/js/pages/PhotoList.vue
@@ -6,6 +6,7 @@
         v-for="photo in photos"
         :key="photo.id"
         :item="photo"
+        @like="onLikeClick"
       />
     </div>
     <Pagination :current-page="currentPage" :last-page="lastPage" />
@@ -54,7 +55,61 @@ export default {
       this.photos = response.data.data
       this.currentPage = response.data.current_page
       this.lastPage = response.data.last_page
-    }
+    },
+
+    // photo.vueのいいねボタンから送られてきたemitが引数に入る
+    onLikeClick ({ id, liked }) {
+      if (! this.$store.getters['auth/check']) {
+        alert('いいね機能を使うにはログインしてください。')
+        return false
+      }
+
+      // いいねがすでにされていた場合とそうでない場合の分岐
+      if (liked) {
+        this.unlike(id)
+      } else {
+        this.like(id)
+      }
+    },
+
+    async like (id) {
+      // apiを叩いていいねをつける
+      const response = await axios.put(`/api/photos/${id}/like`)
+
+      // エラーハンドリング
+      if (response.status !== OK) {
+        this.$store.commit('error/setCode', response.status);
+        return false
+      }
+
+      // いいねがつけられた際のフロント画面の更新
+      this.photos = this.photos.map(photo => {
+        if (photo.id === response.data.photo_id) {
+          photo.likes_count += 1,
+          photo.liked_by_user = true
+        }
+        return photo
+      })
+    },
+
+    async unlike (id) {
+      const response = await axios.delete(`/api/photos/${id}/like`)
+
+      // エラーハンドリング
+      if (response.status !== OK) {
+        this.$store.commit('error/setCode', response.status);
+        return false
+      }
+
+      // いいねが取り消された際のフロント画面の更新
+      this.photos = this.photos.map(photo => {
+        if (photo.id === response.data.photo_id) {
+          photo.likes_count -= 1,
+          photo.liked_by_user = false
+        }
+        return photo
+      })
+    },
   },
 
   watch: {

--- a/src/laravel/routes/api.php
+++ b/src/laravel/routes/api.php
@@ -26,6 +26,12 @@ Route::get('/photos/{id}', 'PhotoController@show')->name('photo.show');
 // コメント送信
 Route::post('/photos/{photo}/comments', 'PhotoController@addComment')->name('photo.comment');
 
+// いいね
+Route::put('/photos/{id}/like', 'PhotoController@like')->name('photo.like');
+
+// いいね削除
+Route::delete('/photos/{id}/like', 'PhotoController@unlike');
+
 
 
 // Route::middleware('auth:api')->get('/user', function (Request $request) {

--- a/src/laravel/tests/Feature/LikeApiTest.php
+++ b/src/laravel/tests/Feature/LikeApiTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Photo;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class LikeApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+
+        factory(Photo::class)->create();
+        $this->photo = Photo::first;
+    }
+
+    /**
+     * @test
+     */
+    public function should_いいねを追加出来る()
+    {
+        // actingAsは認証
+        $response = $this->actingAs($this->user)
+            ->json('PUT', route('photo.like', [
+                'id' => $this->post->id,
+            ]));
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'photo_id' => $this->photo->id,
+            ]);
+
+        // いいねがついているかどうかは0,1でステータス管理を行う
+        $this->assertEquals(1, $this->photo->likes()->count());
+
+    }
+
+    /**
+     * @test
+     */
+    public function should_2回同じ写真にいいねがついても1個しかいいねがつかない()
+    {
+        $param = ['id' => $this->photo->id];
+        $this->actingAs($this->user)->json('PUT', route('photo.like', $param));
+        // 2回目のいいね処理
+        $this->actingAs($this->user)->json('PUT', route('photo.like', $param));
+)
+        $this->assertEquals(1, $this->photo->likes()->count());
+
+    }
+
+    /**
+     * @test
+     */
+    public function should_いいねを解除できる()
+    {
+        $this->photo->likes()->attach($this->user->id);
+
+        $response = $this->actingAs($this->user)
+            ->json('DELETE', route('photo.like', [
+                'id' => $this->photo->id,
+            ]));
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'photo_id' => $this->photo->id,
+            ]);
+
+        $this->assertEquals(0, $this->photo->likes()->count());
+    }
+}

--- a/src/laravel/tests/Feature/LikeApiTest.php
+++ b/src/laravel/tests/Feature/LikeApiTest.php
@@ -52,7 +52,7 @@ class LikeApiTest extends TestCase
         $this->actingAs($this->user)->json('PUT', route('photo.like', $param));
         // 2回目のいいね処理
         $this->actingAs($this->user)->json('PUT', route('photo.like', $param));
-)
+        // likes()はphotoモデル内で定義
         $this->assertEquals(1, $this->photo->likes()->count());
 
     }

--- a/src/laravel/tests/Feature/LikeApiTest.php
+++ b/src/laravel/tests/Feature/LikeApiTest.php
@@ -19,7 +19,7 @@ class LikeApiTest extends TestCase
         $this->user = factory(User::class)->create();
 
         factory(Photo::class)->create();
-        $this->photo = Photo::first;
+        $this->photo = Photo::first();
     }
 
     /**
@@ -30,7 +30,7 @@ class LikeApiTest extends TestCase
         // actingAsは認証
         $response = $this->actingAs($this->user)
             ->json('PUT', route('photo.like', [
-                'id' => $this->post->id,
+                'id' => $this->photo->id,
             ]));
 
         $response->assertStatus(200)

--- a/src/laravel/tests/Feature/PhotoDetailApiTest.php
+++ b/src/laravel/tests/Feature/PhotoDetailApiTest.php
@@ -44,6 +44,8 @@ class PhotoDetailApiTest extends TestCase
                         ];
                     })
                     ->all(),
+                'liked_by_user' => false,
+                'likes_count' => 0,
             ]);
     }
 }

--- a/src/laravel/tests/Feature/PhotoListApiTest.php
+++ b/src/laravel/tests/Feature/PhotoListApiTest.php
@@ -50,7 +50,9 @@ class PhotoListApiTest extends TestCase
             ->assertJsonCount(5, 'data')
             // レスポンスJSONのdata項目が期待値と合致すること
             ->assertJsonFragment([
-                "data" => $expected_data,
+                'data' => $expected_data,
+                'liked_by_user' => false,
+                'likes_count' => 0,
             ]);
     }
 }

--- a/src/laravel/tests/Feature/PhotoListApiTest.php
+++ b/src/laravel/tests/Feature/PhotoListApiTest.php
@@ -40,6 +40,8 @@ class PhotoListApiTest extends TestCase
                 'owner' => [
                     'name' => $photo->owner->name,
                 ],
+                'liked_by_user' => false,
+                'likes_count' => 0,
             ];
         })
         ->all();
@@ -51,8 +53,6 @@ class PhotoListApiTest extends TestCase
             // レスポンスJSONのdata項目が期待値と合致すること
             ->assertJsonFragment([
                 'data' => $expected_data,
-                'liked_by_user' => false,
-                'likes_count' => 0,
             ]);
     }
 }


### PR DESCRIPTION
# WHAT 
- インデックスページ
  - いいね数が表示されるように変更
    - jsonにlikes_countとliked_by_userを追加
      - ikes_countはいいね数のデータが入る
      - iked_by_userはそのユーザーがいいねしているかどうかのt/fが入る
    - photoモデルにlikesリレーションを用意。n+1問題を回避できるようにした
  - 自分がいいねしているときにいいねボタンのビューが変わるように実装
    - liked_by_userの判定値を参照してビューの出しわけといいねをつけるか解除するかを行う